### PR TITLE
Skip unions

### DIFF
--- a/clang/include/clang/Basic/DiagnosticASTKinds.td
+++ b/clang/include/clang/Basic/DiagnosticASTKinds.td
@@ -343,4 +343,6 @@ def warn_padded_struct_size : Warning<
   InGroup<Padded>, DefaultIgnore;
 def warn_unnecessary_packed : Warning<
   "packed attribute is unnecessary for %0">, InGroup<Packed>, DefaultIgnore;
+def warn_randomize_attr_union : Warning<
+  "union declared with 'randomize_layout' attribute">, InGroup<DiagGroup<"randomize-layout">>;
 }

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -2990,7 +2990,7 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
   
   bool ShouldBeRandomized = D->getAttr<RandomizeLayoutAttr>() != nullptr;
    
-  if (ShouldBeRandomized) {
+  if (ShouldBeRandomized && !D->isUnion()) {
     Randstruct randstruct;
     randstruct.reorganizeFields(*this,D);
   }

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -2989,10 +2989,16 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
   const ASTRecordLayout *NewEntry = nullptr;
   
   bool ShouldBeRandomized = D->getAttr<RandomizeLayoutAttr>() != nullptr;
-   
-  if (ShouldBeRandomized && !D->isUnion()) {
-    Randstruct randstruct;
-    randstruct.reorganizeFields(*this,D);
+  if (ShouldBeRandomized) {
+    // There is no technical benefit to randomizing the fields of a union
+    // since they all share the same offset of zero.
+    if (D->isUnion()) {
+      getDiagnostics().Report(D->getLocation(), diag::warn_randomize_attr_union);
+    }
+    else {
+      Randstruct randstruct;
+      randstruct.reorganizeFields(*this,D);
+    }
   }
 
   if (isMsLayout(*this)) {


### PR DESCRIPTION
Forgot to bring this over when we originally ported from the plugin. Closes #23 

With this PR, the Clang compiler will not randomize unions and it will emit a warning when someone decorates their union with the `randomize_layout` attribute.

```
/home/kuehlcon/llvm-project/build/bin/clang -g -Wno-format poc.c -o rand
poc.c:33:7: warning: union declared with 'randomize_layout' attribute [-Wrandomize-layout]
union u {
    ^
```

`clang-test`:

```
[100%] Running the Clang regression tests
llvm-lit: /home/kuehlcon/llvm-project/llvm/utils/lit/lit/llvm/config.py:337: note: using clang: /home/kuehlcon/llvm-project/build/bin/clang
Testing Time: 402.89s                                                                       
  Expected Passes    : 14089                                            
  Expected Failures  : 19                               
  Unsupported Tests  : 62
  [100%] Built target check-clang                     
  [100%] Built target clang-test 
```